### PR TITLE
Fix filename match in contextual search

### DIFF
--- a/src/main/java/build/chronicle/aide/dc/AdocContextualSearch.java
+++ b/src/main/java/build/chronicle/aide/dc/AdocContextualSearch.java
@@ -58,7 +58,11 @@ public class AdocContextualSearch {
      * @param lines the lines of the file to search
      * @return a list of matches found in the file, 0 indexed
      */
-    public List<int[]> searchFile(List<String> lines) {
+    public List<int[]> searchFile(Path path, List<String> lines) {
+        if (path != null && matches(path)) {
+            return List.of(new int[]{0, lines.size() - 1});
+        }
+
         List<int[]> matches = new ArrayList<>();
         int index = 0;
         int prevStart = -1, prevEnd = -1;
@@ -81,6 +85,10 @@ public class AdocContextualSearch {
             matches.add(new int[]{prevStart, prevEnd});
         }
         return matches;
+    }
+
+    public List<int[]> searchFile(List<String> lines) {
+        return searchFile(null, lines);
     }
 
     private int findStart(List<String> lines, int index) {

--- a/src/main/java/build/chronicle/aide/dc/AdocDocumentEngine.java
+++ b/src/main/java/build/chronicle/aide/dc/AdocDocumentEngine.java
@@ -244,7 +244,7 @@ public class AdocDocumentEngine {
             // If a search pattern is configured, perform a contextual search.
             List<int[]> matches;
             if (searchPattern != null && !searchPattern.isEmpty()) {
-                matches = contextualSearch.searchFile(lines);
+                matches = contextualSearch.searchFile(path, lines);
                 if (matches.isEmpty()) {
                     if (verbose) {
                         System.out.println("VERBOSE: No matches found in file: " + path);

--- a/src/test/java/build/chronicle/aide/dc/AdocContextualSearchTest.java
+++ b/src/test/java/build/chronicle/aide/dc/AdocContextualSearchTest.java
@@ -24,7 +24,7 @@ class AdocContextualSearchTest {
         AdocContextualSearch search = new AdocContextualSearch("Service", 2);
         assertTrue(search.matches(Path.of("ServiceExample.java")), "Expected file name to match search pattern");
 
-        List<int[]> matches = search.searchFile(content);
+        List<int[]> matches = search.searchFile(Path.of("ServiceExample.java"), content);
         assertEquals(1, matches.size(), "Expected one match because the filename matches the pattern");
         int[] match = matches.get(0);
         assertEquals(0, match[0], "Match should start at line 1");
@@ -49,7 +49,7 @@ class AdocContextualSearchTest {
         AdocContextualSearch search = new AdocContextualSearch("count", 1);
         assertFalse(search.matches(Path.of("Example.java")), "Expected file name to not match search pattern");
 
-        List<int[]> matches = search.searchFile(content);
+        List<int[]> matches = search.searchFile(Path.of("Example.java"), content);
         assertEquals(2, matches.size(), "Expected two matches in file content");
 
         int[] firstMatch = matches.get(0);
@@ -59,7 +59,7 @@ class AdocContextualSearchTest {
         assertEquals("[6, 9]", Arrays.toString(secondMatch), "First match should start at line 7 and end at line 10");
 
         AdocContextualSearch search2 = new AdocContextualSearch("count", 3);
-        List<int[]> matches2 = search2.searchFile(content);
+        List<int[]> matches2 = search2.searchFile(Path.of("Example.java"), content);
         assertEquals(1, matches2.size(), "Expected one match in file content");
         int[] match = matches2.get(0);
         assertEquals("[0, 9]", Arrays.toString(match), "Match should start at line 1 and end at line 9");
@@ -75,7 +75,7 @@ class AdocContextualSearchTest {
 
         AdocContextualSearch search = new AdocContextualSearch("NonExistentPattern", 1);
 
-        List<int[]> matches = search.searchFile(content);
+        List<int[]> matches = search.searchFile(Path.of("NoMatch.java"), content);
         assertTrue(matches.isEmpty(), "Expected no matches when the pattern is not found");
     }
 }


### PR DESCRIPTION
## Summary
- support filename matching in `AdocContextualSearch`
- use the new API in `AdocDocumentEngine`
- update contextual search tests for new method

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*