### PR TITLE
Fix 128KB docs

### DIFF
--- a/src/main/adoc/adoc-file-filter-req.adoc
+++ b/src/main/adoc/adoc-file-filter-req.adoc
@@ -85,6 +85,6 @@ Unit tests ensure this logic is correct:
 - Exclude files starting with `out-`.
 
 6. **Size Limit**:
-- Exclude files over 64 KB or failing a size read.
+- Exclude files over 128 KB or failing a size read.
 
 By respecting these rules and the `.gitignore` results, `AdocFileFilter` ensures that only relevant, manageable files are processed by the engine.

--- a/src/test/java/build/chronicle/aide/dc/AdocFileFilterTest.java
+++ b/src/test/java/build/chronicle/aide/dc/AdocFileFilterTest.java
@@ -85,7 +85,7 @@ class AdocFileFilterTest {
     @Test
     void testLargeFileExclusion() throws IOException {
         // Create a file just over 128 KB
-        byte[] largeData = new byte[(128 << 10) + 1]; // 64KB + 1
+        byte[] largeData = new byte[(128 << 10) + 1]; // 128KB + 1
         Path largeFile = tempDir.resolve("bigfile.bin");
         Files.write(largeFile, largeData);
 
@@ -105,7 +105,7 @@ class AdocFileFilterTest {
 
         // Should pass local checks (assuming it's not overshadowed, not out-, etc.)
         assertTrue(filter.include(smallFile),
-                "File under 64KB and not excluded by other rules => included");
+                "File under 128KB and not excluded by other rules => included");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update requirement doc for AdocFileFilter to note 128 KB limit
- correct test comments in AdocFileFilterTest

## Testing
- `mvn -q test` *(fails: `mvn` not found)*